### PR TITLE
feat: 원본 문장에 인식된 단어가 포함되어 있는지 비교하는 기능 추가

### DIFF
--- a/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedSentence.java
+++ b/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedSentence.java
@@ -1,11 +1,16 @@
 package com.example.memic.recognizedSentence.domain;
 
 import com.example.memic.recognizedSentence.exception.InvalidRecognizedException;
-import jakarta.persistence.Column;
+import com.example.memic.transcription.domain.TranscriptionSentence;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.Arrays;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,16 +21,52 @@ import lombok.Setter;
 @Setter
 public class RecognizedSentence {
 
+    private static final double VALID_RANGE_FACTOR = 0.3;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 1000)
-    private String recognizedSentence;
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    private List<RecognizedWord> recognizedWords;
 
-    public RecognizedSentence(String recognizedSentence) {
+    public RecognizedSentence(String recognizedSentence, TranscriptionSentence originalSentence) {
         validate(recognizedSentence);
-        this.recognizedSentence = recognizedSentence;
+        recognizedWords = createRecognizedWords(recognizedSentence, originalSentence);
+    }
+
+    private List<RecognizedWord> createRecognizedWords(String recognizedSentence, TranscriptionSentence originalSentence) {
+        List<String> originalWords = originalSentence.getWords();
+        int numberOfOriginalWords = originalWords.size();
+        int validTargetRange = (int) Math.round(numberOfOriginalWords * VALID_RANGE_FACTOR);
+        List<RecognizedWord> recognizedWords = Arrays.stream(recognizedSentence.split(" "))
+                                                     .map(RecognizedWord::new)
+                                                     .toList();
+
+        for (int i = 0; i < recognizedWords.size(); i++) {
+            RecognizedWord targetWord = recognizedWords.get(i);
+            int validFirstTargetWordIndex = Math.max(i - validTargetRange, 0);
+            int validLastTargetWordIndex = Math.min(i + validTargetRange - 1, numberOfOriginalWords - 1) + 1;
+
+            if (validLastTargetWordIndex < validFirstTargetWordIndex) {
+                validFirstTargetWordIndex = validLastTargetWordIndex;
+            }
+
+            if (containsInValidRange(originalWords, validFirstTargetWordIndex, validLastTargetWordIndex, targetWord)) {
+                targetWord.match();
+            }
+        }
+        return recognizedWords;
+    }
+
+    private boolean containsInValidRange(
+            List<String> originalWords,
+            int validFirstTargetWordIndex,
+            int validLastTargetWordIndex,
+            RecognizedWord targetWord
+    ) {
+        return originalWords.subList(validFirstTargetWordIndex, validLastTargetWordIndex)
+                            .contains(targetWord.getWord());
     }
 
     private void validate(String content) {

--- a/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedWord.java
+++ b/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedWord.java
@@ -1,0 +1,33 @@
+package com.example.memic.recognizedSentence.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class RecognizedWord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String word;
+
+    private boolean isMatchedWithTranscription;
+
+    public RecognizedWord(final String word) {
+        this.word = word;
+        this.isMatchedWithTranscription = false;
+    }
+
+    void match() {
+        this.isMatchedWithTranscription = true;
+    }
+}

--- a/src/main/java/com/example/memic/recognizedSentence/dto/RecognizedSentenceResponse.java
+++ b/src/main/java/com/example/memic/recognizedSentence/dto/RecognizedSentenceResponse.java
@@ -1,20 +1,21 @@
 package com.example.memic.recognizedSentence.dto;
 
 import com.example.memic.recognizedSentence.domain.RecognizedSentence;
-import com.example.memic.transcription.domain.Sentence;
+import com.example.memic.transcription.domain.TranscriptionSentence;
+import java.util.List;
 
 public record RecognizedSentenceResponse(
         Long id,
         Long SentenceId,
         String sentence,
-        String recognizedSentence
+        List<RecognizedWordResponse> recognizedWords
 ) {
-    public static RecognizedSentenceResponse of(RecognizedSentence recognizedSentence, Sentence sentence) {
+    public static RecognizedSentenceResponse of(RecognizedSentence recognizedSentence, TranscriptionSentence transcriptionSentence) {
         return new RecognizedSentenceResponse(
                 recognizedSentence.getId(),
-                sentence.getId(),
-                sentence.getContent(),
-                recognizedSentence.getRecognizedSentence()
+                transcriptionSentence.getId(),
+                transcriptionSentence.getContent(),
+                RecognizedWordResponse.from(recognizedSentence)
         );
     }
 }

--- a/src/main/java/com/example/memic/recognizedSentence/dto/RecognizedWordResponse.java
+++ b/src/main/java/com/example/memic/recognizedSentence/dto/RecognizedWordResponse.java
@@ -1,0 +1,20 @@
+package com.example.memic.recognizedSentence.dto;
+
+import com.example.memic.recognizedSentence.domain.RecognizedSentence;
+import java.util.List;
+
+public record RecognizedWordResponse(
+        String word,
+        boolean isMatchedWithTranscription
+) {
+
+    public static List<RecognizedWordResponse> from(final RecognizedSentence recognizedSentence) {
+        return recognizedSentence.getRecognizedWords()
+                                 .stream()
+                                 .map(recognizedWord -> new RecognizedWordResponse(
+                                         recognizedWord.getWord(),
+                                         recognizedWord.isMatchedWithTranscription()
+                                 ))
+                                 .toList();
+    }
+}

--- a/src/main/java/com/example/memic/transcription/domain/Transcription.java
+++ b/src/main/java/com/example/memic/transcription/domain/Transcription.java
@@ -29,15 +29,15 @@ public class Transcription {
 
   @OneToMany(cascade = CascadeType.PERSIST)
   @JoinColumn(name = "transcription_id", updatable = false, nullable = false)
-  private List<Sentence> sentences;
+  private List<TranscriptionSentence> transcriptionSentences;
 
   public Transcription(String url, Map<LocalTime, String> sentences) {
     validate(url);
     this.url = url;
-    this.sentences = sentences.entrySet().stream()
-                              .map(entry -> new Sentence(entry.getKey(), entry.getValue()))
-                              .sorted()
-                              .toList();
+    this.transcriptionSentences = sentences.entrySet().stream()
+                                           .map(entry -> new TranscriptionSentence(entry.getKey(), entry.getValue()))
+                                           .sorted()
+                                           .toList();
   }
 
   private void validate(String url) {

--- a/src/main/java/com/example/memic/transcription/domain/TranscriptionSentence.java
+++ b/src/main/java/com/example/memic/transcription/domain/TranscriptionSentence.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,7 +15,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
-public class Sentence implements Comparable<Sentence> {
+public class TranscriptionSentence implements Comparable<TranscriptionSentence> {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -24,7 +25,7 @@ public class Sentence implements Comparable<Sentence> {
 
     private String content;
 
-    public Sentence(LocalTime startPoint, String content) {
+    public TranscriptionSentence(LocalTime startPoint, String content) {
         validate(content);
         this.startPoint = startPoint;
         this.content = content;
@@ -36,8 +37,12 @@ public class Sentence implements Comparable<Sentence> {
         }
     }
 
+    public List<String> getWords() {
+        return List.of(content.split(" "));
+    }
+
     @Override
-    public int compareTo(Sentence o) {
+    public int compareTo(TranscriptionSentence o) {
         return this.startPoint.compareTo(o.startPoint);
     }
 }

--- a/src/main/java/com/example/memic/transcription/domain/TranscriptionSentenceRepository.java
+++ b/src/main/java/com/example/memic/transcription/domain/TranscriptionSentenceRepository.java
@@ -5,12 +5,12 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
-public interface SentenceRepository extends Repository<Sentence, Long> {
+public interface TranscriptionSentenceRepository extends Repository<TranscriptionSentence, Long> {
 
 
-    Optional<Sentence> findById(Long id);
+    Optional<TranscriptionSentence> findById(Long id);
 
-    default Sentence getById(Long id) {
+    default TranscriptionSentence getById(Long id) {
         return findById(id).orElseThrow(() -> new EntityNotFoundException("아이디에 해당하는 문장이 없습니다."));
     }
 }

--- a/src/main/java/com/example/memic/transcription/dto/SentenceResponse.java
+++ b/src/main/java/com/example/memic/transcription/dto/SentenceResponse.java
@@ -1,6 +1,6 @@
 package com.example.memic.transcription.dto;
 
-import com.example.memic.transcription.domain.Sentence;
+import com.example.memic.transcription.domain.TranscriptionSentence;
 import java.time.LocalTime;
 
 public record SentenceResponse(
@@ -9,11 +9,11 @@ public record SentenceResponse(
         String sentence
 ) {
 
-    public static SentenceResponse fromEntity(Sentence sentence) {
+    public static SentenceResponse fromEntity(TranscriptionSentence transcriptionSentence) {
         return new SentenceResponse(
-                sentence.getId(),
-                sentence.getStartPoint(),
-                sentence.getContent()
+                transcriptionSentence.getId(),
+                transcriptionSentence.getStartPoint(),
+                transcriptionSentence.getContent()
         );
     }
 }

--- a/src/main/java/com/example/memic/transcription/dto/TranscriptionResponse.java
+++ b/src/main/java/com/example/memic/transcription/dto/TranscriptionResponse.java
@@ -13,9 +13,10 @@ public record TranscriptionResponse(
         return new TranscriptionResponse(
                 transcription.getId(),
                 transcription.getUrl(),
-                transcription.getSentences().stream()
-                        .map(SentenceResponse::fromEntity)
-                        .toList()
+                transcription.getTranscriptionSentences()
+                             .stream()
+                             .map(SentenceResponse::fromEntity)
+                             .toList()
         );
     }
 }

--- a/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
+++ b/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
@@ -1,6 +1,5 @@
 package com.example.memic.transcription.infrastructure;
 
-import com.example.memic.recognizedSentence.domain.RecognizedSentence;
 import com.example.memic.transcription.domain.Transcription;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -100,13 +99,12 @@ public class WhisperApiClient {
         return logMap;
     }
 
-    public RecognizedSentence transcribeSpeech(MultipartFile file) {
+    public String transcribeSpeech(MultipartFile file) {
         HttpEntity<MultiValueMap<String, Object>> requestEntity = createRequestSpeechEntity(file);
         ResponseEntity<String> response = restTemplate.postForEntity("", requestEntity, String.class);
 
         String output = response.getBody().toString();
-        String speechTranscription = processSpeechTranscription(output);
-        return new RecognizedSentence(speechTranscription);
+        return processSpeechTranscription(output);
     }
 
     private HttpEntity<MultiValueMap<String, Object>> createRequestSpeechEntity(MultipartFile file) {
@@ -120,8 +118,7 @@ public class WhisperApiClient {
 
     private String processSpeechTranscription(String transcription) {
         int transcriptionLength = transcription.length();
-        String parsed = transcription.substring(START_PREFIX, transcriptionLength - LAST_SUFFIX);
 
-        return parsed;
+        return transcription.substring(START_PREFIX, transcriptionLength - LAST_SUFFIX);
     }
 }

--- a/src/test/java/com/example/memic/recognizedSentence/domain/RecognizedTranscriptionSentenceTest.java
+++ b/src/test/java/com/example/memic/recognizedSentence/domain/RecognizedTranscriptionSentenceTest.java
@@ -1,0 +1,110 @@
+package com.example.memic.recognizedSentence.domain;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.example.memic.transcription.domain.TranscriptionSentence;
+import java.time.LocalTime;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+class RecognizedTranscriptionSentenceTest {
+
+    @Test
+    void 원본_문장과_정확히_일치하면_Recognized_Word의_일치여부가_전부_True이다() {
+        //given
+        final var originalSentence = new TranscriptionSentence(LocalTime.MIDNIGHT, "This is a test.");
+        final var rawRecognizedSentence = "This is a test.";
+
+        //when
+        final var recognizedSentence = new RecognizedSentence(rawRecognizedSentence, originalSentence);
+
+        //then
+        assertTrue(
+                recognizedSentence.getRecognizedWords()
+                                  .stream()
+                                  .allMatch(RecognizedWord::isMatchedWithTranscription)
+        );
+    }
+
+    @Test
+    void 원본_문장에_없는_단어는_일치여부가_False이다() {
+        //given
+        final var originalSentence = new TranscriptionSentence(LocalTime.MIDNIGHT, "This is a test.");
+        final var rawRecognizedSentence = "This is a test. Hello";
+
+        //when
+        final var recognizedSentence = new RecognizedSentence(rawRecognizedSentence, originalSentence);
+
+        final var notMatchedWords = recognizedSentence.getRecognizedWords()
+                                                      .stream()
+                                                      .filter(recognizedWord -> !recognizedWord.isMatchedWithTranscription())
+                                                      .toList();
+        //then
+        SoftAssertions.assertSoftly(
+                softly -> {
+                    assertEquals(1, notMatchedWords.size());
+                    softly.assertThat(notMatchedWords.get(0).getWord()).isEqualTo("Hello");
+                }
+        );
+    }
+
+    @Test
+    void 인덱스가_일치하지_않더라도_일정_범위_안에_단어가_존재하면_일치여부는_True이다() {
+        //given
+        final var originalSentence = new TranscriptionSentence(LocalTime.MIDNIGHT, "This is a Hello test.");
+        final var rawRecognizedSentence = "This is a test. Hello";
+
+        //when
+        final var recognizedSentence = new RecognizedSentence(rawRecognizedSentence, originalSentence);
+
+        //then
+        assertTrue(
+                recognizedSentence.getRecognizedWords()
+                                  .stream()
+                                  .allMatch(RecognizedWord::isMatchedWithTranscription)
+        );
+    }
+
+    @Test
+    void 원본_문장에_존재하더라도_일정_범위_이상_떨어져있다면_일치여부는_False이다() {
+        //given
+        final var originalSentence = new TranscriptionSentence(LocalTime.MIDNIGHT, "This is a test.");
+        final var rawRecognizedSentence = "This is a wrong range test.";
+
+        //when
+        final var recognizedSentence = new RecognizedSentence(rawRecognizedSentence, originalSentence);
+
+        final var notMatchedWords = recognizedSentence.getRecognizedWords()
+                                                      .stream()
+                                                      .filter(recognizedWord -> !recognizedWord.isMatchedWithTranscription())
+                                                      .toList();
+
+        //then
+        SoftAssertions.assertSoftly(
+                softly -> {
+                    assertEquals(3, notMatchedWords.size());
+                    softly.assertThat(notMatchedWords.get(0).getWord()).isEqualTo("wrong");
+                    softly.assertThat(notMatchedWords.get(1).getWord()).isEqualTo("range");
+                    softly.assertThat(notMatchedWords.get(2).getWord()).isEqualTo("test.");
+                }
+        );
+    }
+
+    @Test
+    void 성능_측정_테스트() {
+        //given
+        final var startTime = System.currentTimeMillis();
+        final var original = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB";
+        final var target = "AAAAAAAAAAAAAAAAB";
+        final var originalSentence = new TranscriptionSentence(LocalTime.MIDNIGHT, original);
+
+        //when
+        final var recognizedSentence = new RecognizedSentence(target, originalSentence);
+        final var endTime = System.currentTimeMillis();
+
+        //then
+        System.out.println(("실행 시간 : " + (endTime - startTime) + "ms"));
+    }
+}

--- a/src/test/java/com/example/memic/recognizedSentence/ui/RecognizedTranscriptionSentenceIntegrationTest.java
+++ b/src/test/java/com/example/memic/recognizedSentence/ui/RecognizedTranscriptionSentenceIntegrationTest.java
@@ -1,19 +1,22 @@
 package com.example.memic.recognizedSentence.ui;
 
 
-import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.memic.recognizedSentence.dto.RecognizedSentenceRequest;
+import com.example.memic.recognizedSentence.dto.RecognizedSentenceResponse;
+import com.example.memic.recognizedSentence.dto.RecognizedWordResponse;
 import com.example.memic.transcription.domain.Transcription;
 import com.example.memic.transcription.domain.TranscriptionRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Files;
 import java.time.LocalTime;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -26,7 +29,7 @@ import org.springframework.util.ResourceUtils;
 @SuppressWarnings("NonAsciiCharacters")
 @AutoConfigureMockMvc
 @SpringBootTest
-class RecognizedSentenceIntegrationTest {
+class RecognizedTranscriptionSentenceIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -41,7 +44,7 @@ class RecognizedSentenceIntegrationTest {
     void 음성을_입력하면_문장을_추출한다() throws Exception {
         final var transcription = new Transcription("https://test", Map.of(LocalTime.now(), "hello"));
         final var savedTranscription = transcriptionRepository.save(transcription);
-        final var firstSentence = savedTranscription.getSentences().get(0);
+        final var firstSentence = savedTranscription.getTranscriptionSentences().get(0);
 
         final var request = new RecognizedSentenceRequest(firstSentence.getId());
         final var speechFile = ResourceUtils.getFile(ResourceUtils.CLASSPATH_URL_PREFIX + "speech.mp3");
@@ -59,14 +62,36 @@ class RecognizedSentenceIntegrationTest {
                 Files.readAllBytes(speechFile.toPath())
         );
 
-        mockMvc.perform(multipart("/v1/recognized-sentences")
-                       .file(sentencePart)
-                       .file(speechPart)
-                       .contentType(MediaType.MULTIPART_FORM_DATA))
-               .andDo(print())
-               .andExpect(status().isOk())
-               .andExpect(jsonPath("$.id").isNumber())
-               .andExpect(jsonPath("$.sentence").value("hello"))
-               .andExpect(jsonPath("$.recognizedSentence", containsString("Do you mind if we stop")));
+        final var response = mockMvc.perform(multipart("/v1/recognized-sentences")
+                                            .file(sentencePart)
+                                            .file(speechPart)
+                                            .contentType(MediaType.MULTIPART_FORM_DATA))
+                                    .andDo(print())
+                                    .andExpect(status().isOk())
+                                    .andExpect(jsonPath("$.id").isNumber())
+                                    .andExpect(jsonPath("$.sentence").value("hello"))
+                                    .andReturn();
+        final var recognizedSentenceResponse = objectMapper.readValue(
+                response.getResponse().getContentAsString(),
+                RecognizedSentenceResponse.class
+        );
+
+        final var fullSentence = recognizedSentenceResponse.recognizedWords()
+                                                           .stream()
+                                                           .map(RecognizedWordResponse::word)
+                                                           .collect(Collectors.joining(" "));
+
+        boolean anyMatched = recognizedSentenceResponse.recognizedWords()
+                                                       .stream()
+                                                       .anyMatch(RecognizedWordResponse::isMatchedWithTranscription);
+
+        SoftAssertions.assertSoftly(
+                softly -> {
+                    softly.assertThat(recognizedSentenceResponse.sentence()).contains("hello");
+                    softly.assertThat(recognizedSentenceResponse.id()).isNotNull();
+                    softly.assertThat(fullSentence).contains("Do you mind");
+                    softly.assertThat(anyMatched).isFalse();
+                }
+        );
     }
 }

--- a/src/test/java/com/example/memic/transcription/domain/TranscriptionSentenceTest.java
+++ b/src/test/java/com/example/memic/transcription/domain/TranscriptionSentenceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 @SuppressWarnings("NonAsciiCharacters")
-class SentenceTest {
+class TranscriptionSentenceTest {
 
     @ParameterizedTest
     @NullAndEmptySource
@@ -18,7 +18,7 @@ class SentenceTest {
         LocalTime time = LocalTime.of(0, 0, 1);
 
         //when
-        ThrowingCallable throwingCallable = () -> new Sentence(time, content);
+        ThrowingCallable throwingCallable = () -> new TranscriptionSentence(time, content);
 
         //then
         assertThatThrownBy(throwingCallable).isExactlyInstanceOf(InvalidTranscriptionException.class);


### PR DESCRIPTION
원본 문장 길이의 30% 를 비교 범위로 하여(소수점은 반올림), 비교 범위 안의 인덱스에 특정 단어가 포함되어 있어야만 유효하게 포함되어 있다고 판단한다.

### 😋 작업한 내용
- 말하기 변환 기능의 응답 형식 변경
    - 원본 문장 안에 사용자가 말한 단어의 포함 여부를 판단하여 응답에 포함시키는 기능 추가
    - 문장 전체 범위에서 포함여부를 판단하지 않고, 유효 범위 안에서 포함 여부를 결정
    - 유효 범위는 (원본 문장의 길이 * 0.3) 을 반올림 한 값 `a`라고 할 때, (타겟 단어의 인덱스 - `a`) 에서  (타겟 단어의 인덱스 + `a`) 까지로 한다.

### 👍 관련 이슈

Resolved : #14 