### PR TITLE
feat: 단어 음성 재녹음 기능 추가

### DIFF
--- a/src/main/java/com/example/memic/recognizedSentence/dto/RecognizedWordResponse.java
+++ b/src/main/java/com/example/memic/recognizedSentence/dto/RecognizedWordResponse.java
@@ -4,6 +4,7 @@ import com.example.memic.recognizedSentence.domain.RecognizedSentence;
 import java.util.List;
 
 public record RecognizedWordResponse(
+        Long id,
         String word,
         boolean isMatchedWithTranscription
 ) {
@@ -12,6 +13,7 @@ public record RecognizedWordResponse(
         return recognizedSentence.getRecognizedWords()
                                  .stream()
                                  .map(recognizedWord -> new RecognizedWordResponse(
+                                         recognizedWord.getId(),
                                          recognizedWord.getWord(),
                                          recognizedWord.isMatchedWithTranscription()
                                  ))

--- a/src/main/java/com/example/memic/speech/application/SpeechService.java
+++ b/src/main/java/com/example/memic/speech/application/SpeechService.java
@@ -1,0 +1,21 @@
+package com.example.memic.speech.application;
+
+import com.example.memic.speech.dto.SpeechWordResponse;
+import com.example.memic.speech.dto.SpeechWordRequest;
+import com.example.memic.transcription.infrastructure.WhisperApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class SpeechService {
+
+    private final WhisperApiClient whisperApiClient;
+    public SpeechWordResponse transcribe(final MultipartFile speech, final SpeechWordRequest request) {
+        String transcribedSpeech = whisperApiClient.transcribeSpeech(speech);
+        boolean wordMatched = request.Original().equalsIgnoreCase(transcribedSpeech);
+
+        return new SpeechWordResponse(transcribedSpeech, wordMatched);
+    }
+}

--- a/src/main/java/com/example/memic/speech/application/SpeechService.java
+++ b/src/main/java/com/example/memic/speech/application/SpeechService.java
@@ -1,7 +1,7 @@
 package com.example.memic.speech.application;
 
-import com.example.memic.speech.dto.SpeechWordResponse;
 import com.example.memic.speech.dto.SpeechWordRequest;
+import com.example.memic.speech.dto.SpeechWordResponse;
 import com.example.memic.transcription.infrastructure.WhisperApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,9 +12,10 @@ import org.springframework.web.multipart.MultipartFile;
 public class SpeechService {
 
     private final WhisperApiClient whisperApiClient;
+
     public SpeechWordResponse transcribe(final MultipartFile speech, final SpeechWordRequest request) {
         String transcribedSpeech = whisperApiClient.transcribeSpeech(speech);
-        boolean wordMatched = request.Original().equalsIgnoreCase(transcribedSpeech);
+        boolean wordMatched = request.originalWord().equalsIgnoreCase(transcribedSpeech);
 
         return new SpeechWordResponse(transcribedSpeech, wordMatched);
     }

--- a/src/main/java/com/example/memic/speech/dto/SpeechWordRequest.java
+++ b/src/main/java/com/example/memic/speech/dto/SpeechWordRequest.java
@@ -1,0 +1,6 @@
+package com.example.memic.speech.dto;
+
+public record SpeechWordRequest(
+        String Original
+) {
+}

--- a/src/main/java/com/example/memic/speech/dto/SpeechWordRequest.java
+++ b/src/main/java/com/example/memic/speech/dto/SpeechWordRequest.java
@@ -1,6 +1,6 @@
 package com.example.memic.speech.dto;
 
 public record SpeechWordRequest(
-        String Original
+        String originalWord
 ) {
 }

--- a/src/main/java/com/example/memic/speech/dto/SpeechWordResponse.java
+++ b/src/main/java/com/example/memic/speech/dto/SpeechWordResponse.java
@@ -1,0 +1,7 @@
+package com.example.memic.speech.dto;
+
+public record SpeechWordResponse(
+        String recognizedWord,
+        boolean wordMatched
+) {
+}

--- a/src/main/java/com/example/memic/speech/ui/SpeechController.java
+++ b/src/main/java/com/example/memic/speech/ui/SpeechController.java
@@ -1,0 +1,29 @@
+package com.example.memic.speech.ui;
+
+import com.example.memic.speech.application.SpeechService;
+import com.example.memic.speech.dto.SpeechWordResponse;
+import com.example.memic.speech.dto.SpeechWordRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("v1")
+@RequiredArgsConstructor
+public class SpeechController {
+
+    private final SpeechService speechService;
+
+    @PostMapping("speeches/words")
+    public ResponseEntity<SpeechWordResponse> transcribeWord(
+            @RequestPart MultipartFile speech,
+            @RequestPart SpeechWordRequest word
+    ) {
+        SpeechWordResponse responses = speechService.transcribe(speech, word);
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/com/example/memic/speech/ui/SpeechController.java
+++ b/src/main/java/com/example/memic/speech/ui/SpeechController.java
@@ -23,7 +23,7 @@ public class SpeechController {
             @RequestPart MultipartFile speech,
             @RequestPart SpeechWordRequest word
     ) {
-        SpeechWordResponse responses = speechService.transcribe(speech, word);
-        return ResponseEntity.ok(responses);
+        SpeechWordResponse response = speechService.transcribe(speech, word);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
+++ b/src/main/java/com/example/memic/transcription/infrastructure/WhisperApiClient.java
@@ -54,7 +54,7 @@ public class WhisperApiClient {
         body.add("file", new FileSystemResource(filePath));
         body.add("model", "whisper-1");
         body.add("response_format", "srt");
-
+        body.add("language", "en");
         return new HttpEntity<>(body);
     }
 
@@ -109,10 +109,10 @@ public class WhisperApiClient {
 
     private HttpEntity<MultiValueMap<String, Object>> createRequestSpeechEntity(MultipartFile file) {
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-            body.add("file", file.getResource());
-            body.add("model", "whisper-1");
-            body.add("response_format", "json");
-
+        body.add("file", file.getResource());
+        body.add("model", "whisper-1");
+        body.add("response_format", "json");
+        body.add("language", "en");
         return new HttpEntity<>(body);
     }
 

--- a/src/test/java/com/example/memic/speech/ui/SpeechIntegrationTest.java
+++ b/src/test/java/com/example/memic/speech/ui/SpeechIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.example.memic.speech.ui;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.memic.speech.dto.SpeechWordRequest;
+import com.example.memic.speech.dto.SpeechWordResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.ResourceUtils;
+
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureMockMvc
+@SpringBootTest
+class SpeechIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 음성과_단어를_입력하면_동일_여부를_반환한다() throws Exception {
+        final var speechFile = ResourceUtils.getFile(ResourceUtils.CLASSPATH_URL_PREFIX + "speech.mp3");
+        final var request = new SpeechWordRequest("test");
+
+        final var speechPart = new MockMultipartFile(
+                "speech",
+                "speech.mp3",
+                "audio/mpeg",
+                Files.readAllBytes(speechFile.toPath())
+        );
+
+        final var wordPart = new MockMultipartFile(
+                "word",
+                "ignored",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsString(request).getBytes()
+        );
+
+        final var response = mockMvc.perform(multipart("/v1/speeches/words")
+                                            .file(speechPart)
+                                            .file(wordPart)
+                                            .contentType(MediaType.MULTIPART_FORM_DATA))
+                                    .andDo(print())
+                                    .andExpect(status().isOk())
+                                    .andExpect(jsonPath("$.recognizedWord").isString())
+                                    .andExpect(jsonPath("$.wordMatched").isBoolean())
+                                    .andReturn();
+
+        final var speechWordResponse = objectMapper.readValue(
+                response.getResponse().getContentAsString(),
+                SpeechWordResponse.class
+        );
+
+        SoftAssertions.assertSoftly(
+                softly -> {
+                    softly.assertThat(speechWordResponse.recognizedWord()).isNotNull();
+                    softly.assertThat(speechWordResponse.wordMatched()).isFalse();
+                }
+        );
+    }
+}


### PR DESCRIPTION
### 😋 작업한 내용

* 음성 파일과 단어 일치 여부 확인
* whisper api 전달시 request 값에 {"language" : "en"} 추가
* 발음 스크립트 불러오기 api의 response값 수정
    * recognizedWords의 배열에 id값 추가

### 👍 관련 이슈
Resolved : #23 