### PR TITLE
fix: 문장 비교시 특수문자와 대소문자를 구별하지 않도록 수정

### DIFF
--- a/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedSentence.java
+++ b/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedSentence.java
@@ -51,22 +51,21 @@ public class RecognizedSentence {
             if (validLastTargetWordIndex < validFirstTargetWordIndex) {
                 validFirstTargetWordIndex = validLastTargetWordIndex;
             }
-
-            if (containsInValidRange(originalWords, validFirstTargetWordIndex, validLastTargetWordIndex, targetWord)) {
-                targetWord.match();
-            }
+            checkSubSentenceContainsWord(originalWords, validFirstTargetWordIndex, validLastTargetWordIndex, targetWord);
         }
         return recognizedWords;
     }
 
-    private boolean containsInValidRange(
+    private void checkSubSentenceContainsWord(
             List<String> originalWords,
             int validFirstTargetWordIndex,
             int validLastTargetWordIndex,
             RecognizedWord targetWord
     ) {
-        return originalWords.subList(validFirstTargetWordIndex, validLastTargetWordIndex)
-                            .contains(targetWord.getWord());
+        originalWords.subList(validFirstTargetWordIndex, validLastTargetWordIndex)
+                     .stream()
+                     .map(word -> word.replaceAll("[^a-zA-Z]", ""))
+                     .forEach(targetWord::checkMatched);
     }
 
     private void validate(String content) {

--- a/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedWord.java
+++ b/src/main/java/com/example/memic/recognizedSentence/domain/RecognizedWord.java
@@ -27,7 +27,13 @@ public class RecognizedWord {
         this.isMatchedWithTranscription = false;
     }
 
-    void match() {
-        this.isMatchedWithTranscription = true;
+    void checkMatched(final String word) {
+        if (this.getWordWithoutPunctuation().equalsIgnoreCase(word)) {
+            this.isMatchedWithTranscription = true;
+        }
+    }
+
+    private String getWordWithoutPunctuation() {
+        return word.replaceAll("[^a-zA-Z0-9]", "");
     }
 }

--- a/src/test/java/com/example/memic/recognizedSentence/domain/RecognizedTranscriptionSentenceTest.java
+++ b/src/test/java/com/example/memic/recognizedSentence/domain/RecognizedTranscriptionSentenceTest.java
@@ -29,6 +29,24 @@ class RecognizedTranscriptionSentenceTest {
     }
 
     @Test
+    void 문장이_일치하면_대소문자_여부와_관계없이_Recognized_Word의_일치여부가_전부_True이다() {
+        //given
+        final var originalSentence = sentenceWithoutTranscription("This, is a test.");
+        final var rawRecognizedSentence = "this IS A Test.";
+
+        //when
+        final var recognizedSentence = new RecognizedSentence(rawRecognizedSentence, originalSentence);
+
+        //then
+        assertTrue(
+                recognizedSentence.getRecognizedWords()
+                                  .stream()
+                                  .allMatch(RecognizedWord::isMatchedWithTranscription)
+        );
+    }
+
+
+    @Test
     void 원본_문장에_없는_단어는_일치여부가_False이다() {
         //given
         final var originalSentence = sentenceWithoutTranscription("This is a test.");


### PR DESCRIPTION
### 😋 작업한 내용
-  문장 비교시 특수문자와 대소문자를 구별하지 않도록 수정

### 👍 관련 이슈

Resolved : #34 