### PR TITLE
fix: localtime을 직접 지정

### DIFF
--- a/src/test/java/com/example/memic/recognizedSentence/ui/RecognizedTranscriptionSentenceIntegrationTest.java
+++ b/src/test/java/com/example/memic/recognizedSentence/ui/RecognizedTranscriptionSentenceIntegrationTest.java
@@ -42,7 +42,7 @@ class RecognizedTranscriptionSentenceIntegrationTest {
 
     @Test
     void 음성을_입력하면_문장을_추출한다() throws Exception {
-        final var transcription = new Transcription("https://test", Map.of(LocalTime.now(), "hello"));
+        final var transcription = new Transcription("https://test", Map.of(LocalTime.of(0, 0), "hello"));
         final var savedTranscription = transcriptionRepository.save(transcription);
         final var firstSentence = savedTranscription.getTranscriptionSentences().get(0);
 


### PR DESCRIPTION
### 😋 작업한 내용
*  LocalTime.now() 메서드에서 생성되는 NanoSecond가 hibernate에서 SQL 값으로 변환시 범위를 넘어가 에러를 반환
* [Hibernate incorrectly converting SQL](https://discourse.hibernate.org/t/hibernate-incorrectly-converting-sql-time-to-localtime-between-12am-and-1am-only-if-using-localtime-now/7866) 실제로 12am ~ 1am 사이에 해당 링크와 같은 에러를 반환하는 사례가 존재
* 해당 링크에서 제시한 `LocalTime.of()`으로 직접 시간을 지정하는 방식으로 수정

### 👍 관련 이슈

Resolved : #38 